### PR TITLE
Make it possible to configure if the image come from path or from android assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ const page1 = PDFPage
   });
 
 // Modify second page in document
-const jpgPath = // Path to a JPG image on the file system...
-const pngPath = // Path to a PNG image on the file system...
+const jpgPath = // in iOS Path to a JPG image on the file system... in Android path to the assert
+const pngPath = // in iOS Path to a PNG image on the file system... in Android path to the assert
 const page2 = PDFPage
   .modify(1)
   .drawText('You can add images to modified pages too!')

--- a/README.md
+++ b/README.md
@@ -118,18 +118,28 @@ const pngPath = // in iOS Path to a PNG image on the file system... in Android p
 const page2 = PDFPage
   .modify(1)
   .drawText('You can add images to modified pages too!')
-  .drawImage(jpgPath, 'jpg', {
-     x: 5,
-     y: 125,
-     width: 200,
-     height: 100,
-  })
-  .drawImage(pngPath, 'png', {
-     x: 5,
-     y: 25,
-     width: 200,
-     height: 100,
-  });
+  .drawImage(
+    jpgPath, 
+    'jpg',
+    {
+      x: 5,
+      y: 125,
+      width: 200,
+      height: 100,
+    },
+    'assets' // 'assets' to get image from Android assets 'path' to get image from imagePath
+  )
+  .drawImage(
+    pngPath,
+    'png',
+    {
+      x: 5,
+      y: 25,
+      width: 200,
+      height: 100,
+    },
+    'path' // 'assets' to get image from Android assets 'path' to get image from imagePath
+   );
 
 // Create a PDF page to add to document
 const page3 = PDFPage

--- a/android/src/main/java/com/hopding/pdflib/factories/PDPageFactory.java
+++ b/android/src/main/java/com/hopding/pdflib/factories/PDPageFactory.java
@@ -123,13 +123,28 @@ public class PDPageFactory {
     private void drawImage(ReadableMap imageActions) throws NoSuchKeyException, IOException {
         String imageType = imageActions.getString("imageType");
         String imagePath = imageActions.getString("imagePath");
+        String imageSource = imageActions.getString("imageSource");
+
         Integer[] coords = getCoords(imageActions, true);
         Integer[] dims   = getDims(imageActions, false);
 
         if (imageType.equals("jpg") || imageType.equals("png")) {
             // Create PDImageXObject
             PDImageXObject image = null;
-            if (imageType.equals("jpg") || imageType.equals("png") == true) {
+
+            if (imageSource.equals("path")) {
+               if (imageType.equals("jpg")) {
+                  Bitmap bmpImage = BitmapFactory.decodeFile(imagePath);
+                  image = JPEGFactory.createFromImage(document, bmpImage);
+               }
+               else { // imageType.equals("png") == true
+                   InputStream in = new FileInputStream(new File(imagePath));
+                   Bitmap bmp = BitmapFactory.decodeStream(in);
+                   image = LosslessFactory.createFromImage(document, bmp);
+               }
+            }
+
+            if (imageSource.equals("asserts")) {
                 InputStream is = ASSET_MANAGER.open(imagePath);
                 Bitmap bmp = BitmapFactory.decodeStream(is);
                 image = LosslessFactory.createFromImage(document, bmp);

--- a/android/src/main/java/com/hopding/pdflib/factories/PDPageFactory.java
+++ b/android/src/main/java/com/hopding/pdflib/factories/PDPageFactory.java
@@ -129,13 +129,9 @@ public class PDPageFactory {
         if (imageType.equals("jpg") || imageType.equals("png")) {
             // Create PDImageXObject
             PDImageXObject image = null;
-            if (imageType.equals("jpg")) {
-                Bitmap bmpImage = BitmapFactory.decodeFile(imagePath);
-                image = JPEGFactory.createFromImage(document, bmpImage);
-            }
-            else { // imageType.equals("png") == true
-                InputStream in = new FileInputStream(new File(imagePath));
-                Bitmap bmp = BitmapFactory.decodeStream(in);
+            if (imageType.equals("jpg") || imageType.equals("png") == true) {
+                InputStream is = ASSET_MANAGER.open(imagePath);
+                Bitmap bmp = BitmapFactory.decodeStream(is);
                 image = LosslessFactory.createFromImage(document, bmp);
             }
 

--- a/js/src/PDFPage.js
+++ b/js/src/PDFPage.js
@@ -22,6 +22,7 @@ export type ImageAction = {
   type: 'image',
   imagePath: string,
   imageType: string,
+  imageSource: string,
   x: number,
   y: number,
   width?: number, // If don't have width & height, will use actual dimensions
@@ -126,19 +127,23 @@ export default class PDFPage {
   }
 
   drawImage = (
-    imagePath: string,
-    imageType: string,
-    options: {
-      x?: number,
-      y?: number,
-      width?: number,
-      height?: number,
-    }={}
+      imagePath: string,
+      imageType: string,
+      options: {
+        x?: number,
+        y?: number,
+        width?: number,
+        height?: number,
+      }={},
+      imageSource: string
   ) => {
     // TODO: Add logic using ReactNative.Image to automatically preserve image
     // dimensions!
     if (!['png', 'jpg'].includes(imageType)) {
       throw new Error('Only JPG and PNG images are currently supported!');
+    }
+    if (!['asserts', 'path'].includes(imageSource)) {
+      throw new Error('Only images from "asserts" and "path" are currently supported!');
     }
     const imageAction: ImageAction = {
       x: 0,
@@ -147,6 +152,7 @@ export default class PDFPage {
       type: 'image',
       imagePath,
       imageType,
+      imageSource
     };
     this.page.actions.push(imageAction);
     return this;


### PR DESCRIPTION
Unfortunately, the PDFLib.getAssetPath() method is not available on Android. So it is very difficult to find out which path has to be specified during image integration. This PR allows the images to be used directly from the Android assets without having to specify an absolute path.