### PR TITLE
Bumped compileSdkVersion, dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,8 +12,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.0'
 
     dexOptions {
         jumboMode true
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -35,7 +35,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.tom_roush:pdfbox-android:1.8.9.1'
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.tom_roush:pdfbox-android:1.8.9.1'
+    implementation 'com.facebook.react:react-native:+'
 }
   


### PR DESCRIPTION
Android side changes only. Since, I need to use this repository to convert Image to PDF, I updated compileSdkVersion to 29, and also replaced the 'compile' keyword with 'implementation' in the dependencies.