### PR TITLE
Upgrade: added androidx libraries

### DIFF
--- a/android/src/main/java/com/hopding/pdflib/PDFLibModule.java
+++ b/android/src/main/java/com/hopding/pdflib/PDFLibModule.java
@@ -4,7 +4,7 @@ package com.hopding.pdflib;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 import android.util.Log;
 
 import com.facebook.react.bridge.NoSuchKeyException;

--- a/android/src/main/java/com/hopding/pdflib/factories/PDPageFactory.java
+++ b/android/src/main/java/com/hopding/pdflib/factories/PDPageFactory.java
@@ -2,7 +2,7 @@ package com.hopding.pdflib.factories;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.support.annotation.RequiresPermission;
+import androidx.annotation.RequiresPermission;
 import android.content.Context;
 import android.content.res.AssetManager;
 


### PR DESCRIPTION
These libraries don't work if you have jetifier support. 

- android.support.v4.content.FileProvider

- android.support.annotation.RequiresPermission